### PR TITLE
ConfirmationPopup: Update terms and conditions notification.

### DIFF
--- a/src/components/ConfirmationPopup.js
+++ b/src/components/ConfirmationPopup.js
@@ -53,7 +53,7 @@ class ConfirmationPopup extends React.Component {
     if (!assetsNotification.acceptedTos) {
       setAssetsStatusState({
         alertType: 'error',
-        alertMessage: 'Please accept our T&C before continuing.',
+        alertMessage: 'Please accept the Terms and Conditions before continuing.',
       });
       return null;
     }


### PR DESCRIPTION
Hi! This is my first contribution to the project. 

Screenshot of the pop-up after the change:

![terms_and_conditions](https://user-images.githubusercontent.com/20819151/47857688-95327d80-ddea-11e8-9e28-0758ec8795b5.png)


Fixes #280