### PR TITLE
Airtable and list asset error handling

### DIFF
--- a/src/apis/brain.js
+++ b/src/apis/brain.js
@@ -417,7 +417,7 @@ export const createAsset = async params =>
             let counterCallsToInternalActions = 0;
 
             // we need to perform a few actions before declaring the listing of the asset as successful
-            const performedInternalAction = () => {
+            const performInternalAction = () => {
               counterCallsToInternalActions++;
               if(counterCallsToInternalActions === requiredCallsToInternalActions){
                 onSuccess(() => {
@@ -434,9 +434,9 @@ export const createAsset = async params =>
               }
             }
 
-            updateAirTableWithNewAsset(futureAssetId, assetName, country, city, collateralMyb, collateralPercentage, performedInternalAction)
-            createEntryForNewCollateral(userAddress, collateral, futureAssetId, performedInternalAction);
-            filesUploaded && uploadFilesToAWS(futureAssetId, fileList, performedInternalAction);
+            updateAirTableWithNewAsset(futureAssetId, assetName, country, city, collateralMyb, collateralPercentage, performInternalAction)
+            createEntryForNewCollateral(userAddress, collateral, futureAssetId, performInternalAction);
+            filesUploaded && uploadFilesToAWS(futureAssetId, fileList, performInternalAction);
 
           } else {
             updateNotification(id, {
@@ -457,7 +457,7 @@ export const createAsset = async params =>
 const uploadFilesToAWS = async (
   assetId,
   fileList,
-  performedInternalAction,
+  performInternalAction,
 ) => {
   try{
     let data = new FormData();
@@ -473,9 +473,9 @@ const uploadFilesToAWS = async (
       }
     )
 
-    performedInternalAction();
+    performInternalAction();
   } catch(err){
-    setTimeout(() => uploadFilesToAWS(assetId, fileList, performedInternalAction), 5000);
+    setTimeout(() => uploadFilesToAWS(assetId, fileList, performInternalAction), 5000);
     debug(err);
   }
 }
@@ -484,7 +484,7 @@ const createEntryForNewCollateral = async (
   address,
   escrow,
   assetId,
-  performedInternalAction,
+  performInternalAction,
 ) => {
   try{
     await axios.post(MYBIT_API_COLLATERAL, {
@@ -492,9 +492,9 @@ const createEntryForNewCollateral = async (
       escrow,
       assetId,
     })
-    performedInternalAction();
+    performInternalAction();
   } catch(err){
-    setTimeout(() => createEntryForNewCollateral(address, escrow, assetId, performedInternalAction), 5000);
+    setTimeout(() => createEntryForNewCollateral(address, escrow, assetId, performInternalAction), 5000);
     debug(err);
   }
 }
@@ -506,7 +506,7 @@ const updateAirTableWithNewAsset = async (
   city,
   collateral,
   collateralPercentage,
-  performedInternalAction,
+  performInternalAction,
 ) => {
   try{
     await axios.post(UPDATE_ASSETS_URL, {
@@ -517,9 +517,9 @@ const updateAirTableWithNewAsset = async (
       collateral,
       collateralPercentage,
     });
-    performedInternalAction();
+    performInternalAction();
   } catch(err){
-    setTimeout(() => updateAirTableWithNewAsset(assetId, assetName, country, city, collateral, collateralPercentage, performedInternalAction), 5000);
+    setTimeout(() => updateAirTableWithNewAsset(assetId, assetName, country, city, collateral, collateralPercentage, performInternalAction), 5000);
     debug(err);
   }
 }

--- a/src/apis/brain.js
+++ b/src/apis/brain.js
@@ -350,6 +350,8 @@ export const createAsset = async params =>
         collateralMyb,
         collateralPercentage,
         amountToBeRaisedInUSD,
+        userAddress,
+        managerPercentage,
       } = params;
       const collateral = window.web3js.utils.toWei(collateralMyb.toString(), 'ether');
       debug(collateral)
@@ -372,8 +374,8 @@ export const createAsset = async params =>
 
       const futureAssetId = generateAssetId(
         window.web3js,
-        params.userAddress,
-        params.managerPercentage,
+        userAddress,
+        managerPercentage,
         amountToBeRaisedInUSD,
         installerId,
         assetType,
@@ -390,7 +392,7 @@ export const createAsset = async params =>
           randomBlockNumber.toString(),
           ipfsHash,
         )
-        .send({ from: params.userAddress })
+        .send({ from: userAddress })
         .on('transactionHash', (transactionHash) => {
           updateNotification(id, {
             listAssetProps: {
@@ -409,54 +411,33 @@ export const createAsset = async params =>
           resolve(false);
         })
         .then( async(receipt) => {
-          //TODO add error handling
           if(receipt.status){
-            const response = await axios.post(UPDATE_ASSETS_URL, {
-              assetId: futureAssetId,
-              assetName: assetName,
-              country: country,
-              city: city,
-              collateral: collateralMyb,
-              collateralPercentage,
-            });
+            const filesUploaded = fileList.length > 0;
+            const requiredCallsToInternalActions = filesUploaded ? 3 : 2;
+            let counterCallsToInternalActions = 0;
 
-            if(fileList.length > 0){
-              let data = new FormData();
-              data.append('assetId', futureAssetId);
-              for(const file of fileList){
-                data.append('file', file.originFileObj);
+            // we need to perform a few actions before declaring the listing of the asset as successful
+            const performedInternalAction = () => {
+              counterCallsToInternalActions++;
+              if(counterCallsToInternalActions === requiredCallsToInternalActions){
+                onSuccess(() => {
+                  updateNotification(id, {
+                    listAssetProps: {
+                      assetName: assetName,
+                      assetId: futureAssetId,
+                    },
+                    status: 'success',
+                  })
+                }, futureAssetId)
+
+                resolve(receipt.status);
               }
-              axios.post(S3_UPLOAD_URL,
-                data, {
-                  headers: {
-                    'Content-Type': 'multipart/form-data'
-                  }
-                }
-              ).then((response) => {
-                debug('success');
-              })
-              .catch((err) => {
-                debug('fail');
-              });
             }
 
-            onSuccess(() => {
-              axios.post(MYBIT_API_COLLATERAL, {
-                address: params.userAddress,
-                escrow: collateral,
-                assetId: futureAssetId,
-              }).catch((error) => {
-                debug(error);
-              })
+            updateAirTableWithNewAsset(futureAssetId, assetName, country, city, collateralMyb, collateralPercentage, performedInternalAction)
+            createEntryForNewCollateral(userAddress, collateral, futureAssetId, performedInternalAction);
+            filesUploaded && uploadFilesToAWS(futureAssetId, fileList, performedInternalAction);
 
-              updateNotification(id, {
-                listAssetProps: {
-                  assetName: assetName,
-                  assetId: futureAssetId,
-                },
-                status: 'success',
-              })
-            }, futureAssetId)
           } else {
             updateNotification(id, {
               listAssetProps: {
@@ -464,17 +445,84 @@ export const createAsset = async params =>
               },
               status: 'error',
             });
+            resolve(assetCreationResponse);
           }
-
-          debug(receipt)
-          resolve(receipt.status);
         });
 
-      resolve(assetCreationResponse);
     } catch (err) {
       reject(err);
     }
   });
+
+const uploadFilesToAWS = async (
+  assetId,
+  fileList,
+  performedInternalAction,
+) => {
+  try{
+    let data = new FormData();
+    data.append('assetId', assetId);
+    for(const file of fileList){
+      data.append('file', file.originFileObj);
+    }
+    await axios.post(S3_UPLOAD_URL,
+      data, {
+        headers: {
+          'Content-Type': 'multipart/form-data'
+        }
+      }
+    )
+
+    performedInternalAction();
+  } catch(err){
+    setTimeout(() => uploadFilesToAWS(assetId, fileList, performedInternalAction), 5000);
+    debug(err);
+  }
+}
+
+const createEntryForNewCollateral = async (
+  address,
+  escrow,
+  assetId,
+  performedInternalAction,
+) => {
+  try{
+    await axios.post(MYBIT_API_COLLATERAL, {
+      address,
+      escrow,
+      assetId,
+    })
+    performedInternalAction();
+  } catch(err){
+    setTimeout(() => createEntryForNewCollateral(address, escrow, assetId, performedInternalAction), 5000);
+    debug(err);
+  }
+}
+
+const updateAirTableWithNewAsset = async (
+  assetId,
+  assetName,
+  country,
+  city,
+  collateral,
+  collateralPercentage,
+  performedInternalAction,
+) => {
+  try{
+    await axios.post(UPDATE_ASSETS_URL, {
+      assetId,
+      assetName,
+      country,
+      city,
+      collateral,
+      collateralPercentage,
+    });
+    performedInternalAction();
+  } catch(err){
+    setTimeout(() => updateAirTableWithNewAsset(assetId, assetName, country, city, collateral, collateralPercentage, performedInternalAction), 5000);
+    debug(err);
+  }
+}
 
 const checkTransactionConfirmation = async (
   transactionHash,

--- a/src/apis/brain.js
+++ b/src/apis/brain.js
@@ -412,8 +412,10 @@ export const createAsset = async params =>
         })
         .then( async(receipt) => {
           if(receipt.status){
+            const numberOfInternalActions = 2;
+            const numberOfInternalActionsWithFileUpload = numberOfInternalActions + 1;
             const filesUploaded = fileList.length > 0;
-            const requiredCallsToInternalActions = filesUploaded ? 3 : 2;
+            const requiredCallsToInternalActions = filesUploaded ? numberOfInternalActionsWithFileUpload : numberOfInternalActions;
             let counterCallsToInternalActions = 0;
 
             // we need to perform a few actions before declaring the listing of the asset as successful


### PR DESCRIPTION
Error handling was added for two cases:

 - Airtable down when the app starts up

It waits until airtable is back up. Since we will switch to IPFS soon I think this solution is sufficient for now.

- Listing an asset

We perform various internal actions when the user lists an asset, added error handling for when those fail.

Please note the code for listing an asset will be refactored. Leaving that for a different task, since it will affect various calls to web3.