### PR TITLE
Replaces the MYB input in List-asset for a % and adds labels

### DIFF
--- a/apis/brain.js
+++ b/apis/brain.js
@@ -189,7 +189,8 @@ export const createAsset = async (onCreateAsset, onApprove, params) => {
     const randomURI = generateRandomURI(window.web3js);
     const api = await Network.api();
     const response = await Network.createAsset({
-      escrow: toWei(collateral),
+      // in case collateral turns out to have more than 18 decimals, force a max.
+      escrow: toWei(collateral.toFixed(18)),
       assetURI: randomURI,
       assetManager: userAddress,
       fundingLength: CROWDSALE_DURATION,

--- a/pages/list-asset/index.js
+++ b/pages/list-asset/index.js
@@ -214,15 +214,13 @@ class ListAssetPage extends React.Component {
             : selectedTokenInfo.balanceInDai;
 
       maxCollateralPercentage = maxAmountAllowedInDai === 0 ? 0 : parseInt((maxAmountAllowedInDai / assetValue) * 100);
-
       const maxInMyb = maxAmountAllowedInDai === 0 ? 0 : convertFromDefaultToken(PLATFORM_TOKEN, supportedTokens, maxAmountAllowedInDai);
       const maxCollateralSelectedToken = maxAmountAllowedInDai === 0 ? 0 : convertFromDefaultToken(selectedToken, supportedTokens, maxAmountAllowedInDai);
-
       switch (name) {
         case "percentage":
           percentage = selectedAmount;
-          myb = convertFromDefaultToken(PLATFORM_TOKEN, supportedTokens, maxAmountAllowedInDai * (selectedAmount / 100))
-          dai = maxAmountAllowedInDai * (selectedAmount / 100)
+          myb = convertFromDefaultToken(PLATFORM_TOKEN, supportedTokens, assetValue * (selectedAmount / 100))
+          dai = assetValue * (selectedAmount / 100)
           collateralSelectedToken = convertFromDefaultToken(selectedToken, supportedTokens, dai)
           break;
         case "myb":

--- a/pages/list-asset/index.js
+++ b/pages/list-asset/index.js
@@ -34,6 +34,7 @@ import {
   convertFromPlatformToken,
   convertFromDefaultToken,
   convertFromTokenToDefault,
+  formatValueForToken,
 } from 'utils/helpers';
 
 const MAX_WIDTH_DESKTOP = "500px";
@@ -221,7 +222,7 @@ class ListAssetPage extends React.Component {
           percentage = selectedAmount;
           myb = convertFromDefaultToken(PLATFORM_TOKEN, supportedTokens, assetValue * (selectedAmount / 100))
           dai = assetValue * (selectedAmount / 100)
-          collateralSelectedToken = convertFromDefaultToken(selectedToken, supportedTokens, dai)
+          collateralSelectedToken = formatValueForToken(convertFromDefaultToken(selectedToken, supportedTokens, dai), selectedToken)
           break;
         case "myb":
           myb = selectedAmount > maxInMyb ? maxInMyb : selectedAmount

--- a/pages/list-asset/slides/collateral.js
+++ b/pages/list-asset/slides/collateral.js
@@ -117,7 +117,7 @@ export const CollateralSlide = ({
   const decimalsOfSelectedTokens = getDecimalsForToken(selectedToken);
   const decimalsOfPlatformToken = getDecimalsForToken(PLATFORM_TOKEN);
   const collateralSelectedTokenFormatted = formatValueForToken(collateralSelectedToken, selectedToken);
-  const collateralPlatformTokenFormatted = formatValueForToken(collateralMyb, PLATFORM_TOKEN);
+
   return (
     <CarouselSlide
       maxWidthDesktop={maxWidthDesktop}
@@ -190,8 +190,8 @@ export const CollateralSlide = ({
             >
               <Label>Currency you pay in</Label>
               <NumericInput
-                defaultValue={collateralSelectedTokenFormatted}
-                value={collateralSelectedTokenFormatted}
+                defaultValue={collateralSelectedToken}
+                value={collateralSelectedToken}
                 min={0}
                 disabled={noBalance}
                 step={decimalsOfSelectedTokens.step}

--- a/pages/list-asset/slides/collateral.js
+++ b/pages/list-asset/slides/collateral.js
@@ -84,6 +84,14 @@ const TokenSelectorWrapper = styled.div`
   }
 `
 
+const Label = styled.div`
+  margin-left: 6px;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 22px;
+  color: ${({theme}) => theme.colors.grayBase};
+`
+
 const Loading = styled(Spin)`
   display: block;
   margin: 0 auto;
@@ -163,14 +171,16 @@ export const CollateralSlide = ({
               disabled={noBalance}
             />
             <MybitInput>
+              <Label>Collateral in {PLATFORM_TOKEN}</Label>
               <NumericInput
-                defaultValue={collateralPlatformTokenFormatted}
-                value={collateralPlatformTokenFormatted}
+                defaultValue={collateralPercentage}
+                value={collateralPercentage}
                 min={0}
-                label={PLATFORM_TOKEN}
-                onChange={value => handleCollateralChange({selectedAmount: value}, "myb")}
-                decimalPlaces={decimalsOfPlatformToken.decimals}
-                step={decimalsOfPlatformToken.step}
+                label="%"
+                max={maxCollateralPercentage}
+                onChange={value => handleCollateralChange({selectedAmount: value}, "percentage")}
+                decimalPlaces={2}
+                step={1}
                 disabled={noBalance}
               />
             </MybitInput>
@@ -178,6 +188,7 @@ export const CollateralSlide = ({
             <TokenSelectorWrapper
               selectorIsDisabled={noBalance}
             >
+              <Label>Currency you pay in</Label>
               <NumericInput
                 defaultValue={collateralSelectedTokenFormatted}
                 value={collateralSelectedTokenFormatted}

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -14,7 +14,7 @@ export const toWei = value => window.web3js.utils.toWei(value.toString(), 'ether
 
 export const formatValueForToken = (value, symbol) => {
   const decimalsForToken = getDecimalsForToken(symbol)
-  return Number(value).toFixed(decimalsForToken.decimals);
+  return Number(Number(value).toFixed(decimalsForToken.decimals));
 }
 
 export const getDecimalsForToken = symbol => {


### PR DESCRIPTION
![collateral](https://user-images.githubusercontent.com/24925905/56098979-22800f00-5eff-11e9-92a4-d196e7993f60.png)

Edit: I've also just made the selected token input fully editable. 