### PR TITLE
Dynamic gas price

### DIFF
--- a/apis/brain.js
+++ b/apis/brain.js
@@ -31,6 +31,7 @@ import BN from 'bignumber.js';
 BN.config({ EXPONENTIAL_AT: 80 });
 
 const SDK_CONTRACTS = require("@mybit/contracts/networks/ropsten/Contracts");
+const GAS = require("@mybit/network.js/gas");
 
 let Network;
 
@@ -130,11 +131,18 @@ const roiEscrow = async assetId =>
     }
   });
 
-export const withdrawAssetManager = async (userAddress, assetId, onTransactionHash, onReceipt, onError) => {
+export const withdrawAssetManager = async (
+  userAddress,
+  assetId,
+  onTransactionHash,
+  onReceipt,
+  onError,
+  gasPrice,
+) => {
   try {
     const assetManagerFunds = await Network.assetManagerFunds();
     assetManagerFunds.methods.withdraw(assetId, userAddress)
-      .send({ from: userAddress, gas: '1000000'})
+      .send({ from: userAddress, gas: '200000', gasPrice})
       .on('transactionHash', (transactionHash) => {
         onTransactionHash();
       })
@@ -148,11 +156,18 @@ export const withdrawAssetManager = async (userAddress, assetId, onTransactionHa
   }
 }
 
-export const withdrawEscrow = async (userAddress, assetId, onTransactionHash, onReceipt, onError) => {
+export const withdrawEscrow = async (
+  userAddress,
+  assetId,
+  onTransactionHash,
+  onReceipt,
+  onError,
+  gasPrice,
+) => {
   try {
     const assetManagerEscrow = await Network.assetManagerEscrow();
     assetManagerEscrow.methods.unlockEscrow(assetId, userAddress)
-      .send({ from: userAddress, gas: '1000000'})
+      .send({ from: userAddress, gas: '200000', gasPrice})
       .on('transactionHash', (transactionHash) => {
         onTransactionHash();
       })
@@ -184,6 +199,7 @@ export const createAsset = async (onCreateAsset, onApprove, params) => {
       amountToBeRaised,
       paymentTokenAddress,
       operatorID,
+      gasPrice,
     } = params;
 
     const randomURI = generateRandomURI(window.web3js);
@@ -200,6 +216,7 @@ export const createAsset = async (onCreateAsset, onApprove, params) => {
       operatorID,
       fundingToken: DEFAULT_TOKEN_CONTRACT,
       paymentToken: paymentTokenAddress,
+      gasPrice,
       createAsset: {
         onTransactionHash: onCreateAsset.onTransactionHash,
         onError: error => processErrorType(error, onCreateAsset.onError),
@@ -248,25 +265,6 @@ export const uploadFilesToAWS = async (
   }
 }
 
-export const createEntryForNewCollateral = async (
-  address,
-  escrow,
-  assetId,
-  performInternalAction,
-) => {
-  try{
-    await axios.post(InternalLinks.MYBIT_API_COLLATERAL, {
-      address,
-      escrow,
-      assetId,
-    })
-    performInternalAction();
-  } catch(err){
-    setTimeout(() => createEntryForNewCollateral(address, escrow, assetId, performInternalAction), 5000);
-    debug(err);
-  }
-}
-
 export const updateAirTableWithNewAsset = async (
   assetId,
   assetName,
@@ -296,6 +294,7 @@ export const payoutAsset = ({
   onTransactionHash,
   onReceipt,
   onError,
+  gasPrice,
 }) => {
   try {
     Network.payout({
@@ -304,17 +303,25 @@ export const payoutAsset = ({
       onTransactionHash,
       onError: error => processErrorType(error, onError),
       onReceipt,
+      gasPrice,
     })
   } catch(error) {
     processErrorType(error, onError)
   }
 }
 
-export const withdrawInvestorProfit = async (userAddress, assetId, onTransactionHash, onReceipt, onError) => {
+export const withdrawInvestorProfit = async (
+  userAddress,
+  assetId,
+  onTransactionHash,
+  onReceipt,
+  onError,
+  gasPrice,
+) => {
   try {
     const dividendTokenETH = await Network.dividendTokenETH(assetId);
     const response = await dividendTokenETH.methods.withdraw()
-      .send({from: userAddress, gas: '1000000'})
+      .send({from: userAddress, gas: '100000', gasPrice})
       .on('transactionHash', (transactionHash) => {
         onTransactionHash();
       })
@@ -336,6 +343,7 @@ export const fundAsset = async (onFundAsset, onApprove, params) => {
       assetId,
       amount,
       paymentToken,
+      gasPrice,
     } = params;
 
     const response = await Network.fundAsset({
@@ -343,6 +351,7 @@ export const fundAsset = async (onFundAsset, onApprove, params) => {
       investor: userAddress,
       paymentToken,
       amount: toWei(amount),
+      gasPrice,
       buyAsset: {
         onTransactionHash: onFundAsset.onTransactionHash,
         onError: error => processErrorType(error, onFundAsset.onError),

--- a/components/AssetDetails/index.js
+++ b/components/AssetDetails/index.js
@@ -18,6 +18,7 @@ const AssetDetails = ({
   fundAsset,
   updateNotification,
   loadingUserInfo,
+  gasPrice,
 }) => {
   const {
     city,
@@ -76,6 +77,7 @@ const AssetDetails = ({
           fundAsset={fundAsset}
           updateNotification={updateNotification}
           loadingUserInfo={loadingUserInfo}
+          gasPrice={gasPrice}
         />
       </AssetDetailsRightCol>
     </AssetDetailsWrapper>

--- a/components/AssetFunding/index.js
+++ b/components/AssetFunding/index.js
@@ -123,6 +123,7 @@ class AssetFunding extends React.Component {
       fundAsset,
       updateNotification,
       loadingUserInfo,
+      gasPrice,
     } = this.props;
 
     const {
@@ -200,6 +201,7 @@ class AssetFunding extends React.Component {
             fundAsset={this.fundAsset}
             cancel={this.resetStep}
             selectedMaxValue={selectedMaxValue}
+            gasPrice={gasPrice}
           />
         )}
         {step === 2 && (

--- a/components/BlockchainContext.js
+++ b/components/BlockchainContext.js
@@ -97,7 +97,7 @@ class BlockchainProvider extends React.Component {
     try {
       this.fetchAssets();
       this.fetchTransactionHistory();
-      this.fetGasPrice();
+      this.fetchGasPrice();
 
     } catch (err) {
       debug(err);
@@ -139,7 +139,7 @@ class BlockchainProvider extends React.Component {
     this.intervalFetchTransactionHistory =
       setInterval(this.fetchTransactionHistory, FETCH_TRANSACTION_HISTORY_TIME);
     this.intervalFetchGasPrice =
-      setInterval(this.fetGasPrice, FETCH_GAS_PRICE);
+      setInterval(this.fetchGasPrice, FETCH_GAS_PRICE);
   }
 
   resetIntervals = () => {
@@ -148,7 +148,7 @@ class BlockchainProvider extends React.Component {
     clearInterval(this.intervalFetchGasPrice);
   }
 
-  fetGasPrice = async () => {
+  fetchGasPrice = async () => {
     let {
       gasPrice,
     } = this.state;

--- a/components/ManageAssetModule/index.js
+++ b/components/ManageAssetModule/index.js
@@ -124,29 +124,31 @@ class ManageAssetModule extends React.Component{
       const isWithdrawingCollateral = withdrawingCollateral.includes(assetId);
       const isWithdrawingAssetManager = withdrawingAssetManager.includes(assetId);
 
-      this.setState({
-        loading: false,
-        assetInfo: {
-          userAddress: metamaskContext.user.address,
-          asset: asset,
-          methods: {
-            withdrawCollateral: !isWithdrawingCollateral ? () => withdrawCollateral(asset, percentageMax, withdrawMax) : undefined,
-            withdrawProfitAssetManager: !isWithdrawingAssetManager ? () => withdrawProfitAssetManager(asset, owedToAssetManager): undefined,
-          },
-          finantialDetails: {
-            assetManagerProfits,
-            collateralData,
-            revenueData,
-            toWithdraw: owedToAssetManager,
-            isWithdrawingCollateral,
-            isWithdrawingAssetManager,
-            profit,
-            withdrawMax,
-            percentageMax,
-            averageProfit,
+      if(this._mounted !== false){
+        this.setState({
+          loading: false,
+          assetInfo: {
+            userAddress: metamaskContext.user.address,
+            asset: asset,
+            methods: {
+              withdrawCollateral: !isWithdrawingCollateral ? () => withdrawCollateral(asset, percentageMax, withdrawMax) : undefined,
+              withdrawProfitAssetManager: !isWithdrawingAssetManager ? () => withdrawProfitAssetManager(asset, owedToAssetManager): undefined,
+            },
+            finantialDetails: {
+              assetManagerProfits,
+              collateralData,
+              revenueData,
+              toWithdraw: owedToAssetManager,
+              isWithdrawingCollateral,
+              isWithdrawingAssetManager,
+              profit,
+              withdrawMax,
+              percentageMax,
+              averageProfit,
+            }
           }
-        }
-      }, () => console.log(this.state));
+        }, () => console.log(this.state));
+      }
       this._processingAssetInfo = false;
     }catch(err){
       this._processingAssetInfo = false;
@@ -158,6 +160,10 @@ class ManageAssetModule extends React.Component{
     if(window){
       this.getData();
     }
+  }
+
+  componentWillUnmount = () => {
+    this._mounted = false;
   }
 
   componentWillReceiveProps = nextProps => {

--- a/components/TokenSelector/index.js
+++ b/components/TokenSelector/index.js
@@ -162,7 +162,7 @@ class TokenSelector extends React.Component {
           <TokenSelectorSearch
             placeholder="Search Token"
             onChange={this.handleSearchInputChanged}
-            maxlength={10}
+            maxLength={10}
           />
           <div>
             <TokenSelectorAmount>

--- a/constants/links.js
+++ b/constants/links.js
@@ -12,8 +12,6 @@ export const InternalLinks = {
  UPDATE_ASSETS: process.env.NODE_ENV === 'development' ? `${host}/api/airtable/update` : '/api/airtable/update',
  S3_UPLOAD: process.env.NODE_ENV === 'development' ? `${host}/api/files/upload` : '/api/files/upload',
  S3_ASSET_FILES: process.env.NODE_ENV === 'development' ? `${host}/api/assets/files` : '/api/assets/files',
- MYBIT_API_COLLATERAL: process.env.NODE_ENV === 'development' ? `${secondHost}/collateral` : `${apiEndpoint}/collateral`,
- PRICES: process.env.NODE_ENV === 'development' ? `${secondHost}/prices` : `${apiEndpoint}/prices`,
  GAS_PRICE: `${apiEndpoint}/gasprice`,
 }
 

--- a/constants/links.js
+++ b/constants/links.js
@@ -14,6 +14,7 @@ export const InternalLinks = {
  S3_ASSET_FILES: process.env.NODE_ENV === 'development' ? `${host}/api/assets/files` : '/api/assets/files',
  MYBIT_API_COLLATERAL: process.env.NODE_ENV === 'development' ? `${secondHost}/collateral` : `${apiEndpoint}/collateral`,
  PRICES: process.env.NODE_ENV === 'development' ? `${secondHost}/prices` : `${apiEndpoint}/prices`,
+ GAS_PRICE: `${apiEndpoint}/gasprice`,
 }
 
 export const ExternalLinks = {

--- a/constants/timers.js
+++ b/constants/timers.js
@@ -2,6 +2,5 @@ export const FETCH_TRANSACTION_HISTORY_TIME = 60 * 1000;
 export const LOAD_METAMASK_USER_DETAILS_TIME = 5 * 1000;
 export const FETCH_ASSETS_TIME = 30 * 1000;
 export const CHECK_LOGIN_TIME = 5 * 1000;
-export const LOAD_PRICES_TIME = 1000 * 60 * 10;
 export const LOAD_SUPPORTED_TOKENS_TIME = 1000 * 60 * 30;
 export const FETCH_GAS_PRICE = 1000 * 60 * 10;

--- a/constants/timers.js
+++ b/constants/timers.js
@@ -4,3 +4,4 @@ export const FETCH_ASSETS_TIME = 30 * 1000;
 export const CHECK_LOGIN_TIME = 5 * 1000;
 export const LOAD_PRICES_TIME = 1000 * 60 * 10;
 export const LOAD_SUPPORTED_TOKENS_TIME = 1000 * 60 * 30;
+export const FETCH_GAS_PRICE = 1000 * 60 * 10;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@antv/data-set": "0.10.1",
-    "@mybit/network.js": "0.0.25",
+    "@mybit/network.js": "0.0.28",
     "@zeit/next-bundle-analyzer": "0.1.2",
     "@zeit/next-css": "1.0.1",
     "airtable": "0.5.8",

--- a/pages/asset/index.js
+++ b/pages/asset/index.js
@@ -23,6 +23,7 @@ class AssetPage extends React.Component {
       handleAssetFavorited,
       fundAsset,
       updateNotification,
+      gasPrice,
     } = blockchainContext;
 
     if (loading.assets) {
@@ -51,6 +52,7 @@ class AssetPage extends React.Component {
           fundAsset={fundAsset}
           updateNotification={updateNotification}
           loadingUserInfo={loading.userAssetsInfo}
+          gasPrice={gasPrice}
         />
       )
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,10 +963,10 @@
     web3-eth-abi "1.0.0-beta.36"
     web3-utils "1.0.0-beta.36"
 
-"@mybit/network.js@0.0.25":
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/@mybit/network.js/-/network.js-0.0.25.tgz#6daefeddd5d0e4b3782eba8702888dc1af422253"
-  integrity sha512-Df87hn7TLzJHB1MXAU8T+W/a4+6I+RhydkLw1YQHoZxNogz5PmjTV9vvrvrPmyLbL2qH/celn8y/d5HK++JYgA==
+"@mybit/network.js@0.0.28":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@mybit/network.js/-/network.js-0.0.28.tgz#3feca4fa2ad6ef9b0397a5d0a6fff9625724f235"
+  integrity sha512-hz+8bI5YqdJyAqbkOgGSpF8vfaOWXzX2HJ3C95FsAif62wtXIYcnLLW9RzAM5Uh5h04lIhGid4Jyd1HuEYOAog==
   dependencies:
     "@mybit/contracts" "0.1.21"
     bignumber.js "^8.0.2"
@@ -8847,7 +8847,7 @@ simple-statistics@~6.1.0:
   resolved "https://registry.yarnpkg.com/simple-statistics/-/simple-statistics-6.1.1.tgz#e3a0799ffc49914d6f421c5a4ac585f6a13e2bad"
   integrity sha512-zGwn0DDRa9Zel4H4n2pjTFIyGoAGpnpjrGIctreCxj5XWrcx9v7Xy7270FkC967WMmcvuc8ZU7m0ZG+hGN7gAA==
 
-"sjcl@github:civicteam/sjcl":
+sjcl@civicteam/sjcl.git:
   version "1.0.8"
   resolved "https://codeload.github.com/civicteam/sjcl/tar.gz/74fcc71a486a41d39200767d9235f6eac9e51f26"
 


### PR DESCRIPTION
We are now pulling the gasPrice from our API endpoint.

As it stands the user should never have to increase the gas in Metamask, Go uses an amount considered to be high, so transactions are fast, if anything the user can decrease it.

Our SDK needs a small touch to also use gasPrice in the Approve calls but other than that its good to go.