### PR TITLE
Using Infura if user doesn't have Metamask

### DIFF
--- a/components/MetamaskContext/index.js
+++ b/components/MetamaskContext/index.js
@@ -132,7 +132,7 @@ class MetamaskProvider extends Component {
         window.web3js = new Web3(window.web3.currentProvider);
         await this.userHasMetamask(false);
       } else {
-        window.web3js = new Web3(new Web3.providers.HttpProvider(PROVIDER_ROPSTEN));
+        window.web3js = new Web3(new Web3.providers.HttpProvider(this.props.backupProvider || PROVIDER_ROPSTEN));
         this.isBrowserSupported();
       }
     } catch(err){


### PR DESCRIPTION
Before we could use Metamask's own providers but that doesn't seem to be possible anymore.