### PR TITLE
Adds tooltips next to the payment types in the Asset Details Page

### DIFF
--- a/components/AssetFundingConfirm/index.js
+++ b/components/AssetFundingConfirm/index.js
@@ -178,6 +178,7 @@ const AssetFundingConfirm = ({
                   tooltipText="If the type of asset is acquired physically and required fiat payments,
                   the asset incurs an additional 8% fee on top of the total investment to cover most exchanges
                   fees in order to transfer the money into its fiat equivalent."
+                  isDark
                 />
               }
               firstValue={formatMonetaryValue(fiatToCryptoFeeDefaultToken)}
@@ -203,6 +204,7 @@ const AssetFundingConfirm = ({
                   tooltipText="Slippage is a necessary part of automated trading reserves.
                     As the relative balance of the two currencies shift due to a purchase,
                     so does the price."
+                  isDark
                 />
               }
               firstValue={

--- a/components/UI/AssetFundingDetails/index.js
+++ b/components/UI/AssetFundingDetails/index.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import { memo } from 'react';
 import Item from './Item';
+import LabelWithTooltip from 'ui/LabelWithTooltip';
 
 const FundingDetailsWrapper = styled.div`
   display: grid;
@@ -36,11 +37,29 @@ const AssetFundingDetails = memo(({
     />
     <Item
       title="Payout"
-      value={cryptoPayout ? 'Crypto' : 'Fiat'}
+      value={
+        <LabelWithTooltip
+          title={cryptoPayout ? 'Crypto' : 'Fiat'}
+          tooltipText={cryptoPayout ?
+            `Asset generates revenue in Crypto, not requiring any manual work to pay the investors` :
+            `Asset generates revenue in Fiat and the Asset Manager handles the conversion to Crypto,
+            manually paying the investors`}
+          isDark
+        />
+      }
     />
     <Item
       title="Acquired"
-      value={cryptoPurchase ? 'Via Crypto' : 'Via Fiat'}
+      value={
+        <LabelWithTooltip
+          title={cryptoPurchase ? 'Via Crypto' : 'Via Fiat'}
+          tooltipText={cryptoPurchase ?
+            `No extra fees, this is the ideal case scenario` :
+            `The asset incurs an additional 8% fee on top of the total investment to cover most exchanges
+            fees in order to transfer the money into its fiat equivalent.`}
+          isDark
+        />
+      }
     />
   </FundingDetailsWrapper>
 ))

--- a/components/UI/LabelWithTooltip.js
+++ b/components/UI/LabelWithTooltip.js
@@ -12,10 +12,12 @@ const LabelWithTooltipWrapper = styled.div`
 const LabelWithTooltip = ({
   title,
   tooltipText,
+  isDark,
 }) => (
   <LabelWithTooltipWrapper>
     {title}
     <TooltipWrapper
+      overlayClassName={isDark ? 'AssetManagerTooltip' : ''}
       arrowPointAtCenter
       placement="top"
       destroyTooltipOnHide


### PR DESCRIPTION
Also made the background of those tooltips and the ones in AssetFundingConfirm dark, to match the Figma design.