### PR TITLE
Small updates to Portfolio and Manage Asset Pages

### DIFF
--- a/components/ManageAsset/index.js
+++ b/components/ManageAsset/index.js
@@ -31,239 +31,241 @@ const COLUMN_SIZE = {
 }
 
 class ManageAsset extends React.Component {
-    constructor(props) {
-      super(props);
-      this.displayProfit = this.displayProfit.bind(this);
-      this.displayCollateral = this.displayCollateral.bind(this);
-      this.state = {
-        chartBoxView: "profit",
-        profitChartView: 'weekly',
-        supportingDocuments: false,
-      };
+  constructor(props) {
+    super(props);
+    this.displayProfit = this.displayProfit.bind(this);
+    this.displayCollateral = this.displayCollateral.bind(this);
+    this.state = {
+      chartBoxView: "profit",
+      profitChartView: 'weekly',
+      supportingDocuments: false,
+    };
+  }
+
+  displayProfit(type) {
+    this.setState({ chartBoxView: "profit", profitChartView: type });
+  }
+
+  displayCollateral() {
+    this.setState({ chartBoxView: "collateral" });
+  }
+
+  getFilesToRender(files, assetId){
+    if(!files || files.length === 0){
+      return <span>None</span>;
     }
+    const toReturn = files.map(file => (
+      <a
+        href={`${InternalLinks.S3}${assetId}:${file}`}
+      >
+        {file}
+      </a>
+    ))
 
-    displayProfit(type) {
-      this.setState({ chartBoxView: "profit", profitChartView: type });
-    }
+    return toReturn;
+  }
 
-    displayCollateral() {
-      this.setState({ chartBoxView: "collateral" });
-    }
+  getNavBarButtons = (asset, error, isCallingPayout, payoutAsset) => {
+    const {
+      assetId,
+      managerHasToCallPayout,
+    } = asset;
 
-    getFilesToRender(files, assetId){
-      if(!files || files.length === 0){
-        return <span>None</span>;
-      }
-      const toReturn = files.map(file => (
-        <a
-          href={`${InternalLinks.S3}${assetId}:${file}`}
-        >
-          {file}
-        </a>
-      ))
+    let sendFundsToOperatorButton = managerHasToCallPayout ? (
+      <Button
+        type="primary"
+        onClick={() => payoutAsset()}
+        loading={isCallingPayout}
+        disabled={isCallingPayout}
+      >
+        Send Funds To Operator
+      </Button>
+    ) : undefined;
 
-      return toReturn;
-    }
+    return (
+      <ManageAssetNavButtons>
+        <BackButton
+          as="/portfolio/managed-assets"
+          href="/portfolio?type=managed-assets"
+        />
+        {!error && (
+          <React.Fragment>
+            <ManageAssetDocsButton
+                type="secondary"
+                selected={this.state.supportingDocuments}
+                onClick={() => this.setState(prevProps => ({supportingDocuments: !prevProps.supportingDocuments}))}
+              >
+              Supporting Documents
+            </ManageAssetDocsButton>
+            {sendFundsToOperatorButton}
+          </React.Fragment>
+        )}
+      </ManageAssetNavButtons>
+    )
+  }
 
-    getNavBarButtons = (asset, error, isCallingPayout, payoutAsset) => {
-      const {
-        assetId,
-        managerHasToCallPayout,
-      } = asset;
+  render() {
+    const {
+      assetInfo = {},
+      threeBox = {},
+      error,
+      loading,
+      metamaskError,
+    } = this.props;
 
-      let sendFundsToOperatorButton = managerHasToCallPayout ? (
-        <Button
-          type="primary"
-          onClick={() => payoutAsset()}
-          loading={isCallingPayout}
-          disabled={isCallingPayout}
-        >
-          Send Funds To Operator
-        </Button>
-      ) : undefined;
 
+    if(loading) {
+      return(
+        <Loading
+          message="Loading asset information"
+          hasBackButton
+        />
+      )
+    } else if(error){
+      const description = getErrorMessage(error.type);
       return (
-        <ManageAssetNavButtons>
-          <BackButton
-            as="/portfolio/managed-assets"
-            href="/portfolio?type=managed-assets"
-          />
-          {!error && (
-            <React.Fragment>
-              <ManageAssetDocsButton
-                  type="secondary"
-                  selected={this.state.supportingDocuments}
-                  onClick={() => this.setState(prevProps => ({supportingDocuments: !prevProps.supportingDocuments}))}
-                >
-                Supporting Documents
-              </ManageAssetDocsButton>
-              {sendFundsToOperatorButton}
-            </React.Fragment>
-          )}
-        </ManageAssetNavButtons>
+        <ErrorPage
+          title="Error"
+          description={description}
+        />
       )
     }
 
-    render() {
-      const {
-        assetInfo = {},
-        threeBox = {},
-        error,
-        loading,
-        metamaskError,
-      } = this.props;
+    const {
+      asset = {},
+      finantialDetails = {},
+      methods = {},
+      userAddress,
+    } = assetInfo;
 
+    const {
+      authorizeThreeBoxSpace,
+      openThreeBoxSpace,
+      postUpdateOnThread,
+      getPostsFromCurrentThread,
+    } = (threeBox.methods || {});
 
-      if(loading) {
-        return(
-          <Loading
-            message="Loading asset information"
-            hasBackButton
-          />
-        )
-      } else if(error){
-        const description = getErrorMessage(error.type);
-        return (
-          <ErrorPage
-            title="Error"
-            description={description}
-          />
-        )
-      }
+    const {
+      hasAuthorizedThreeBox,
+      hasOpenedGoSpace,
+      syncingThreeBox,
+      syncingThreeBoxThread,
+      loadingThreeBoxThreadAPIAuthorization,
+      loadingThreeBoxSpaceAuthorization,
+      loadingThreeBoxThreadPostRequest
+    } = threeBox
 
-      const {
-        asset = {},
-        finantialDetails = {},
-        methods = {},
-        userAddress,
-      } = assetInfo;
+    const {
+      withdrawCollateral,
+      withdrawProfitAssetManager,
+      payoutAsset,
+    } = methods;
 
-      const {
-        authorizeThreeBoxSpace,
-        openThreeBoxSpace,
-        postUpdateOnThread,
-        getPostsFromCurrentThread,
-      } = (threeBox.methods || {});
+    const {
+      assetManagerProfits,
+      averageProfit,
+      collateralData,
+      percentageMax,
+      withdrawMax,
+      profit,
+      revenueData,
+      toWithdraw,
+      isWithdrawingCollateral,
+      isWithdrawingAssetManager,
+      isCallingPayout,
+    } = finantialDetails;
 
-      const {
-        hasAuthorizedThreeBox,
-        hasOpenedGoSpace,
-        syncingThreeBox,
-        syncingThreeBoxThread,
-        loadingThreeBoxThreadAPIAuthorization,
-        loadingThreeBoxSpaceAuthorization,
-        loadingThreeBoxThreadPostRequest
-      } = threeBox
+    const {
+      profitChartView,
+      chartBoxView,
+      supportingDocuments,
+    } = this.state;
 
-      const {
-        withdrawCollateral,
-        withdrawProfitAssetManager,
-        payoutAsset,
-      } = methods;
+    const {
+      assetId,
+      collateral,
+      managerPercentage,
+      fundingGoal,
+      assetIncome,
+      city,
+      country,
+      name,
+      imageSrc,
+      partner,
+      files,
+      defaultData,
+      assetManagerCollateral,
+      funded,
+    } = asset;
 
-      const {
-        assetManagerProfits,
-        averageProfit,
-        collateralData,
-        percentageMax,
-        withdrawMax,
-        profit,
-        revenueData,
-        toWithdraw,
-        isWithdrawingCollateral,
-        isWithdrawingAssetManager,
-        isCallingPayout,
-      } = finantialDetails;
+    const assetListingUrl = `/explore/${assetId}`;
 
-      const {
-        profitChartView,
-        chartBoxView,
-        supportingDocuments,
-      } = this.state;
-
-      const {
-        assetId,
-        collateral,
-        managerPercentage,
-        fundingGoal,
-        assetIncome,
-        city,
-        country,
-        name,
-        imageSrc,
-        partner,
-        files,
-        defaultData,
-        assetManagerCollateral,
-      } = asset;
-
-      const assetListingUrl = `/explore/${assetId}`;
-
-      return (
-        <div>
-          {this.getNavBarButtons(asset, error, isCallingPayout, payoutAsset)}
-            {!error && (
-              <ManageAssetContentWrapper>
+    return (
+      <div>
+        {this.getNavBarButtons(asset, error, isCallingPayout, payoutAsset)}
+          {!error && (
+            <ManageAssetContentWrapper>
+              <Col {...COLUMN_SIZE}>
+                <ManageAssetAssetInfo
+                  imageSrc={defaultData.imageSrc}
+                  assetId={assetId}
+                  name={defaultData.name}
+                  city={city}
+                  country={country}
+                  fundingGoal={fundingGoal}
+                  assetIncome={assetIncome}
+                  profit={profit}
+                  averageProfit={averageProfit}
+                  toWithdraw={toWithdraw}
+                  isWithdrawingAssetManager={isWithdrawingAssetManager}
+                  withdrawProfitAssetManager={withdrawProfitAssetManager}
+                  managerPercentage={managerPercentage}
+                  funded={funded}
+                />
+                <ManageAssetUpdates
+                  authorizeThreeBoxSpace={authorizeThreeBoxSpace}
+                  hasAuthorizedThreeBox={hasAuthorizedThreeBox}
+                  openThreeBoxSpace={openThreeBoxSpace}
+                  hasOpenedGoSpace={hasOpenedGoSpace}
+                  postUpdateOnThread={postUpdateOnThread}
+                  getPostsFromCurrentThread={getPostsFromCurrentThread}
+                  syncingThreeBox={syncingThreeBox}
+                  syncingThreeBoxThread={syncingThreeBoxThread}
+                  loadingThreeBoxThreadPostRequest={loadingThreeBoxThreadPostRequest}
+                  loadingThreeBoxThreadAPIAuthorization={loadingThreeBoxThreadAPIAuthorization}
+                  loadingThreeBoxSpaceAuthorization={loadingThreeBoxSpaceAuthorization}
+                />
+              </Col>
+              {!supportingDocuments && (
                 <Col {...COLUMN_SIZE}>
-                  <ManageAssetAssetInfo
-                    imageSrc={defaultData.imageSrc}
-                    assetId={assetId}
-                    name={defaultData.name}
-                    city={city}
-                    country={country}
-                    fundingGoal={fundingGoal}
-                    assetIncome={assetIncome}
-                    profit={profit}
-                    averageProfit={averageProfit}
-                    toWithdraw={toWithdraw}
-                    isWithdrawingAssetManager={isWithdrawingAssetManager}
-                    withdrawProfitAssetManager={withdrawProfitAssetManager}
+                  <ManageAssetGraphs
+                    chartBoxView={chartBoxView}
+                    revenueData={revenueData}
+                    profitChartView={profitChartView}
                     managerPercentage={managerPercentage}
-                  />
-                  <ManageAssetUpdates
-                    authorizeThreeBoxSpace={authorizeThreeBoxSpace}
-                    hasAuthorizedThreeBox={hasAuthorizedThreeBox}
-                    openThreeBoxSpace={openThreeBoxSpace}
-                    hasOpenedGoSpace={hasOpenedGoSpace}
-                    postUpdateOnThread={postUpdateOnThread}
-                    getPostsFromCurrentThread={getPostsFromCurrentThread}
-                    syncingThreeBox={syncingThreeBox}
-                    syncingThreeBoxThread={syncingThreeBoxThread}
-                    loadingThreeBoxThreadPostRequest={loadingThreeBoxThreadPostRequest}
-                    loadingThreeBoxThreadAPIAuthorization={loadingThreeBoxThreadAPIAuthorization}
-                    loadingThreeBoxSpaceAuthorization={loadingThreeBoxSpaceAuthorization}
+                    displayProfit={this.displayProfit}
+                    displayCollateral={this.displayCollateral}
+                    assetManagerCollateral={assetManagerCollateral}
+                    collateralData={collateralData}
+                    fundingGoal={fundingGoal}
+                    isWithdrawingCollateral={isWithdrawingCollateral}
+                    withdrawCollateral={withdrawCollateral}
                   />
                 </Col>
-                {!supportingDocuments && (
-                  <Col {...COLUMN_SIZE}>
-                    <ManageAssetGraphs
-                      chartBoxView={chartBoxView}
-                      revenueData={revenueData}
-                      profitChartView={profitChartView}
-                      managerPercentage={managerPercentage}
-                      displayProfit={this.displayProfit}
-                      displayCollateral={this.displayCollateral}
-                      assetManagerCollateral={assetManagerCollateral}
-                      collateralData={collateralData}
-                      fundingGoal={fundingGoal}
-                      isWithdrawingCollateral={isWithdrawingCollateral}
-                      withdrawCollateral={withdrawCollateral}
-                    />
-                  </Col>
-                )}
-                {supportingDocuments && (
-                  <Col {...COLUMN_SIZE}>
-                    <DocumentsManager
-                      assetId={assetId}
-                      files={files}
-                    />
-                  </Col>
-                )}
-              </ManageAssetContentWrapper>
-            )}
-        </div>
-        )
-    }
+              )}
+              {supportingDocuments && (
+                <Col {...COLUMN_SIZE}>
+                  <DocumentsManager
+                    assetId={assetId}
+                    files={files}
+                  />
+                </Col>
+              )}
+            </ManageAssetContentWrapper>
+          )}
+      </div>
+      )
+  }
 }
 
 export default withMetamaskErrors(ManageAsset, false, true);

--- a/components/ManageAsset/manageAssetAssetInfo.js
+++ b/components/ManageAsset/manageAssetAssetInfo.js
@@ -59,6 +59,7 @@ const ManageAssetAssetInfo = React.memo(({
   isWithdrawingAssetManager,
   withdrawProfitAssetManager,
   managerPercentage,
+  funded,
 }) => (
   <AssetTemplate
     backgroundImage={imageSrc}
@@ -100,6 +101,7 @@ const ManageAssetAssetInfo = React.memo(({
         >
           <Button
             type="default"
+            disabled={!funded}
           >
             Deposit Revenue
           </Button>

--- a/components/UI/Asset/AssetPortfolioManaged/index.js
+++ b/components/UI/Asset/AssetPortfolioManaged/index.js
@@ -22,12 +22,6 @@ const AssetPortfolioManaged = ({
   funded,
   assetId,
   fundingStage,
-  owedToInvestor,
-  numberOfInvestors,
-  ownership,
-  withdrawing,
-  withdrawInvestorProfit,
-  unrealizedProfit,
   toWithdraw,
   managerPercentage,
   totalProfitAssetManager,
@@ -35,33 +29,19 @@ const AssetPortfolioManaged = ({
   pastDate,
   fundingGoal,
   fundingProgress,
-  managerHasToCallPayout,
-  callingPayout,
-  payoutAsset,
-  defaultData,
 }) => {
-
-  const text = managerHasToCallPayout ? 'Send funds to operator' : 'Manage asset';
-  const url = managerHasToCallPayout ? undefined : `/manage?id=${assetId}`;
-  const urlAs = managerHasToCallPayout ? undefined : `/manage/${assetId}`;
   const button = (
     <Button
       type="secondary"
-      onClick={managerHasToCallPayout ? () => payoutAsset({
-        assetId,
-        defaultData,
-      }) : undefined}
-      loading={callingPayout}
-      disabled={callingPayout}
     >
-      {text}
+      Manage asset
     </Button>
   )
 
-  const buttonWithLink = url && (
+  const buttonWithLink = (
     <Link
-      as={urlAs}
-      href={url}
+      as={`/manage?id=${assetId}`}
+      href={`/manage/${assetId}`}
     >
       {button}
     </Link>
@@ -141,7 +121,7 @@ const AssetPortfolioManaged = ({
           )}
         </div>
         <AssetPortfolioManagedButtons>
-          {buttonWithLink || button}
+          {buttonWithLink}
         </AssetPortfolioManagedButtons>
       </AssetPortfolioManagedSection>
     </AssetPortfolioManagedWrapper>


### PR DESCRIPTION
- Removes 'Send funds to operator' from the Portfolio Page, Managed Assets section.
- Disables 'Deposit Revenue' in Manage Asset Page if the asset hasn't been fully funded.