### PR TITLE
use now.sh version 1 that supports docker, change contract from SAI to DAI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,6 @@ jobs:
             VERY_SANITIZED_BRANCH=$(tr "." "-" <<<$SANITIZED_BRANCH)
             echo ${GIT_HASH} > version
             cp CONTRIBUTORS contributors
-            BUILD_URL=$(npx now --name app.mybit.io -t $NOW_DEVELOPMENT_TOKEN --public)
+            BUILD_URL=$(npx now --name app.mybit.io --docker -t $NOW_DEVELOPMENT_TOKEN --public)
             npx now alias ${BUILD_URL} ${GIT_HASH}-app-mybit-io-dev -t $NOW_DEVELOPMENT_TOKEN
             npx now alias ${BUILD_URL} ${VERY_SANITIZED_BRANCH}-app-mybit-io-dev -t $NOW_DEVELOPMENT_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,6 @@ jobs:
             VERY_SANITIZED_BRANCH=$(tr "." "-" <<<$SANITIZED_BRANCH)
             echo ${GIT_HASH} > version
             cp CONTRIBUTORS contributors
-            BUILD_URL=$(npx now --name app.mybit.io --docker -t $NOW_DEVELOPMENT_TOKEN --public)
+            BUILD_URL=$(npx now --name app.mybit.io -t $NOW_DEVELOPMENT_TOKEN --public)
             npx now alias ${BUILD_URL} ${GIT_HASH}-app-mybit-io-dev -t $NOW_DEVELOPMENT_TOKEN
             npx now alias ${BUILD_URL} ${VERY_SANITIZED_BRANCH}-app-mybit-io-dev -t $NOW_DEVELOPMENT_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Logs
+#Logs
 logs
 *.log
 npm-debug.log*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ script:
   - GIT_HASH=$(git rev-parse --short HEAD)
   - echo ${GIT_HASH} > version
   - cp CONTRIBUTORS contributors
-  - BUILD_URL=$(npx now --name app.mybit.io --docker -t $NOW_PROD_TOKEN)
+  - BUILD_URL=$(npx now --name app.mybit.io -t $NOW_PROD_TOKEN)
   - if [ "$TRAVIS_BRANCH" = "develop" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then npx now alias ${BUILD_URL} app-staging.mybit.io -t $NOW_PROD_TOKEN; fi
   - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then npx now alias ${BUILD_URL} app.mybit.io -t $NOW_PROD_TOKEN; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ script:
   - GIT_HASH=$(git rev-parse --short HEAD)
   - echo ${GIT_HASH} > version
   - cp CONTRIBUTORS contributors
-  - BUILD_URL=$(npx now --name app.mybit.io -t $NOW_PROD_TOKEN)
+  - BUILD_URL=$(npx now --name app.mybit.io --docker -t $NOW_PROD_TOKEN)
   - if [ "$TRAVIS_BRANCH" = "develop" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then npx now alias ${BUILD_URL} app-staging.mybit.io -t $NOW_PROD_TOKEN; fi
   - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then npx now alias ${BUILD_URL} app.mybit.io -t $NOW_PROD_TOKEN; fi

--- a/now.json
+++ b/now.json
@@ -12,5 +12,5 @@
     "AWS_ACCESS_KEY": "@aws-access-key",
     "GOOGLE_PLACES_API_KEY": "@google-places-api-key"
   },
-  "version": 2
+  "version": 1
 }


### PR DESCRIPTION
now.sh version 2.0 does not support docker
https://spectrum.chat/zeit/general/how-would-i-deploy-this-docker-based-solution-with-now-v2~cf5caeca-31fd-4bd9-81a8-a68a6ce1e54a

specified on now.json to use the version 1